### PR TITLE
Refactoring - Harmonise sys.exit() and disallow direct execution of submodules

### DIFF
--- a/scripts/step03_explore_examples/01_naive_rag/main.py
+++ b/scripts/step03_explore_examples/01_naive_rag/main.py
@@ -23,8 +23,7 @@ def chat():
         question = question.strip()
 
         if question.lower() == "exit":
-            print("Goodbye!")
-            sys.exit()
+            break
 
         elif not question:
             print("Please provide a question.")
@@ -85,7 +84,7 @@ def main():
             continue
         elif option == "2":
             chat()
-            break
+            continue
         elif option == "3":
             print("Goodbye!")
             sys.exit()

--- a/scripts/step03_explore_examples/02_advanced_rag/README.md
+++ b/scripts/step03_explore_examples/02_advanced_rag/README.md
@@ -40,6 +40,14 @@ Retrieving relevant document for RAG can be challenging. In this example, we dem
 
 First, we will extract title data from the user query. After that, we will use the title data to filter the documents stored in the SAP HANA Cloud Vector Engine during the retrieval process. The retrieved documents will be used to generate responses using the SAP GenAI Hub.
 
+## Example: HANA Self Query
+
+Getting an accurate response from an LLM can be a tedious task. In the 'Self Query' example, we tried to overcome this challenge. Building on that, in this example we demonstrate the usage of SelfQueryRetriever for HANA vectorstore to filter relevant documents before performing semantic search in order to deliver a more accurate response.
+
+We demonstrate how SelfQueryRetriever utilizes the LLM to create a structured query tailored for HANA DB. This structured query is then applied to the underlying HANA database, which stores document embeddings and metadata. The retriever not only matches the user’s query semantically with the contents of stored documents, but it can also extract filters from the query based on metadata (such as episode or podcast title) and apply these filters to efficiently retrieve relevant documents from HANA DB.
+
+This process enables the retriever to go beyond simple semantic matching, using metadata-based filters and structured queries to retrieve highly relevant results.
+
 ## Example: Rewrite-Retrieve-Read
 
 In many GenAI cases users are allowed to formulate questions in a free form. That can lead to ambiguity in the question that LLMs can not understand. There are two possible outcomes out of it: LLM will guess the meaning of the query and possibly hallucinate or it will answer something like 'I don't know'. This example shows how to use the SAP BTP services to implement query rewriting to reduce query ambiguity and improve the quality of the response.
@@ -52,12 +60,5 @@ In many GenAI cases users are allowed to formulate questions in a free form. Tha
 
 We use LangChain to generate multiple queries similar to the user query, retrieve relevant documents for all of them and then combine results together using Reciprocal Rank Fusion algorithm. The final list of documents is then used to generate the response. We will also compare results with and without RAG Fusion.
 
-## Example: HANA Self Query
-
-Getting an accurate response from an LLM can be a tedious task. In the 'Self Query' example, we tried to overcome this challenge. Building on that, in this example we demonstrate the usage of SelfQueryRetriever for HANA vectorstore to filter relevant documents before performing semantic search in order to deliver a more accurate response.
-
-We demonstrate how SelfQueryRetriever utilizes the LLM to create a structured query tailored for HANA DB. This structured query is then applied to the underlying HANA database, which stores document embeddings and metadata. The retriever not only matches the user’s query semantically with the contents of stored documents, but it can also extract filters from the query based on metadata (such as episode or podcast title) and apply these filters to efficiently retrieve relevant documents from HANA DB.
-
-This process enables the retriever to go beyond simple semantic matching, using metadata-based filters and structured queries to retrieve highly relevant results.
 
 

--- a/scripts/step03_explore_examples/02_advanced_rag/main.py
+++ b/scripts/step03_explore_examples/02_advanced_rag/main.py
@@ -35,9 +35,9 @@ def main():
         print("1: Prerequisite - Ingest sample data")
         print("2: Advanced RAG - Compare Splitter Methods")
         print("3: Advanced RAG - Self Query")
-        print("4: Advanced RAG - Rewrite Retrieve Read")
-        print("5: Advanced RAG - RAG Fusion")
-        print("6: Advanced RAG - HANA Self Query")
+        print("4: Advanced RAG - HANA Self Query")
+        print("5: Advanced RAG - Rewrite Retrieve Read")
+        print("6: Advanced RAG - RAG Fusion")
         print("7: Exit\n")
 
         option = input("Which task would you like to run?").strip()
@@ -56,13 +56,13 @@ def main():
             execute_self_query()
             continue
         elif option == "4":
-            execute_rewrite_retrieve_read()
+            execute_hana_self_query()            
             continue
         elif option == "5":
             execute_rag_fusion()
             continue
         elif option == "6":
-            execute_hana_self_query()
+            execute_rewrite_retrieve_read()
             continue
         elif option == "7":
             print("Goodbye!")

--- a/scripts/step03_explore_examples/02_advanced_rag/main.py
+++ b/scripts/step03_explore_examples/02_advanced_rag/main.py
@@ -2,7 +2,7 @@ import logging
 import sys
 
 from utils.env import init_env
-from utils.hana import teardown_hana_table
+from utils.hana import teardown_hana_table as execute_teardown_hana_table
 
 from helpers.config import (
     SAP_DOCS_TABLE_NAME,
@@ -10,12 +10,12 @@ from helpers.config import (
 )
 
 from src import (
-    ingest_main,
-    rag_fusion_main,
-    rewrite_retrieve_read_main,
-    self_query_main,
-    split_data_main,
-    hana_self_query_main,
+    execute_ingestion,
+    execute_rag_fusion,
+    execute_rewrite_retrieve_read,
+    execute_self_query,
+    execute_split_data,
+    execute_hana_self_query,
 )
 
 log = logging.getLogger(__name__)
@@ -43,27 +43,27 @@ def main():
         option = input("Which task would you like to run?").strip()
 
         if option == "0":
-            teardown_hana_table(SAP_DOCS_TABLE_NAME)
-            teardown_hana_table(PODCASTS_TABLE_NAME)
+            execute_teardown_hana_table(SAP_DOCS_TABLE_NAME)
+            execute_teardown_hana_table(PODCASTS_TABLE_NAME)
             continue
         elif option == "1":
-            ingest_main()
+            execute_ingestion()
             continue
         elif option == "2":
-            split_data_main()
+            execute_split_data()
             continue
         elif option == "3":
-            self_query_main()
+            execute_self_query()
             continue
         elif option == "4":
-            rewrite_retrieve_read_main()
+            execute_rewrite_retrieve_read()
             continue
         elif option == "5":
-            rag_fusion_main()
+            execute_rag_fusion()
             continue
         elif option == "6":
-            hana_self_query_main()
-            break
+            execute_hana_self_query()
+            continue
         elif option == "7":
             print("Goodbye!")
             sys.exit()

--- a/scripts/step03_explore_examples/02_advanced_rag/src/__init__.py
+++ b/scripts/step03_explore_examples/02_advanced_rag/src/__init__.py
@@ -1,6 +1,6 @@
-from .ingest import main as ingest_main
-from .split_data import main as split_data_main
-from .rag_fusion import main as rag_fusion_main
-from .self_query import main as self_query_main
-from .rewrite_retrieve_read import main as rewrite_retrieve_read_main
-from .hana_self_query import main as hana_self_query_main
+from .ingest import execute_ingestion
+from .split_data import execute_split_data
+from .rag_fusion import execute_rag_fusion
+from .self_query import execute_self_query
+from .rewrite_retrieve_read import execute_rewrite_retrieve_read
+from .hana_self_query import execute_hana_self_query

--- a/scripts/step03_explore_examples/02_advanced_rag/src/hana_self_query.py
+++ b/scripts/step03_explore_examples/02_advanced_rag/src/hana_self_query.py
@@ -16,7 +16,7 @@ from utils.env import init_env
 log = logging.getLogger(__name__)
 
 
-def main():
+def execute_hana_self_query():
     llm, _, db = setup_components(PODCASTS_TABLE_NAME)
     question = "What is the summary of the episode 65?"
 
@@ -141,7 +141,3 @@ def qa_documents_with_filters(db, llm, question, advanced_db_filter=None):
         log.error(f"Error during QA chain execution: {str(e)}")
 
 
-if __name__ == "__main__":
-    # Load environment variables
-    init_env()
-    main()

--- a/scripts/step03_explore_examples/02_advanced_rag/src/ingest.py
+++ b/scripts/step03_explore_examples/02_advanced_rag/src/ingest.py
@@ -131,10 +131,7 @@ def ingest_sap_docs():
         log.error(f"Error during SAP documents ingestion: {str(e)}")
 
 
-def main():
+def execute_ingestion():
     ingest_podcasts()
     ingest_sap_docs()
 
-
-if __name__ == "__main__":
-    main()

--- a/scripts/step03_explore_examples/02_advanced_rag/src/rag_fusion.py
+++ b/scripts/step03_explore_examples/02_advanced_rag/src/rag_fusion.py
@@ -13,7 +13,7 @@ from helpers.factory import setup_components
 log = logging.getLogger(__name__)
 
 
-def main():
+def execute_rag_fusion():
     llm, _, db = setup_components(SAP_DOCS_TABLE_NAME)
 
     template = """
@@ -112,7 +112,3 @@ def reciprocal_rank_fusion(results: list[list], k=60):
     return reranked_results
 
 
-if __name__ == "__main__":
-    # Load environment variables
-    init_env()
-    main()

--- a/scripts/step03_explore_examples/02_advanced_rag/src/rewrite_retrieve_read.py
+++ b/scripts/step03_explore_examples/02_advanced_rag/src/rewrite_retrieve_read.py
@@ -3,7 +3,6 @@ import logging
 from langchain_core.output_parsers import StrOutputParser
 from langchain_core.prompts import ChatPromptTemplate
 from langchain_core.runnables import RunnablePassthrough
-from utils.env import init_env
 
 from helpers.factory import setup_components
 from helpers.config import SAP_DOCS_TABLE_NAME
@@ -12,7 +11,7 @@ from helpers.config import SAP_DOCS_TABLE_NAME
 log = logging.getLogger(__name__)
 
 
-def main():
+def execute_rewrite_retrieve_read():
     print("Rewrite, retrieve, and read")
 
     llm, _, db = setup_components(SAP_DOCS_TABLE_NAME)
@@ -83,9 +82,3 @@ def invoke_query_with_rewrite(llm, simple_query, prompt, retriever):
 
     rewritten_result = rewrite_retrieve_read_chain.invoke(simple_query)
     print("QA result after query rewrite: ", rewritten_result)
-
-
-if __name__ == "__main__":
-    # Load environment variables
-    init_env()
-    main()

--- a/scripts/step03_explore_examples/02_advanced_rag/src/self_query.py
+++ b/scripts/step03_explore_examples/02_advanced_rag/src/self_query.py
@@ -5,7 +5,6 @@ from langchain.chains import RetrievalQA
 from langchain_core.prompts import PromptTemplate
 from langchain_core.pydantic_v1 import BaseModel, Field
 
-from utils.env import init_env
 
 from helpers.config import PODCASTS_TABLE_NAME
 from helpers.factory import setup_components
@@ -13,7 +12,7 @@ from helpers.factory import setup_components
 log = logging.getLogger(__name__)
 
 
-def main():
+def execute_self_query():
     llm, _, db = setup_components(PODCASTS_TABLE_NAME)
     question = "What is the summary of the episode 65?"
 
@@ -89,9 +88,3 @@ def qa_documents_with_filters(db, llm, question, advanced_db_filter=None):
         print("Title:", doc.metadata["title"], " Page Number:", doc.metadata["page"])
 
     print("Result:", result["result"])
-
-
-if __name__ == "__main__":
-    # Load environment variables
-    init_env()
-    main()

--- a/scripts/step03_explore_examples/02_advanced_rag/src/split_data.py
+++ b/scripts/step03_explore_examples/02_advanced_rag/src/split_data.py
@@ -10,13 +10,11 @@ from llama_index.core import SimpleDirectoryReader
 from llama_index.core.node_parser import SemanticSplitterNodeParser
 from llama_index.embeddings.langchain import LangchainEmbedding
 
-from utils.env import init_env
-
 
 log = logging.getLogger(__name__)
 
 
-def main():
+def execute_split_data():
     print("Compare different splitting strategies")
 
     # Load the documents from a GitHub repository
@@ -137,9 +135,3 @@ def semantic_split_docs_into_chunks(documents: list[Document]):
     log.info(f"Split {len(documents)} documents into {len(nodes)} chunks.")
 
     return nodes
-
-
-if __name__ == "__main__":
-    # Load environment variables
-    init_env()
-    main()

--- a/scripts/step03_explore_examples/04_rag_on_mixed_data/main.py
+++ b/scripts/step03_explore_examples/04_rag_on_mixed_data/main.py
@@ -31,8 +31,7 @@ def main():
             question = input("Ask a question or type 'exit' to leave: ")
 
             if question.lower() == "exit":
-                print("Goodbye!")
-                sys.exit()
+                break
 
             log.info(f"Asking a question: {question}")
             agent_executor.invoke({"input": question})
@@ -54,7 +53,7 @@ def main():
             continue
         elif option == "2":
             ask()
-            break
+            continue
         elif option == "3":
             print("Goodbye!")
             sys.exit()

--- a/scripts/step03_explore_examples/05_multi_modal_rag/library/retrieve.py
+++ b/scripts/step03_explore_examples/05_multi_modal_rag/library/retrieve.py
@@ -68,7 +68,6 @@ def ask(llm, retriever):
 
         # Check if the user wants to exit
         if question.lower() == "exit":
-            print("Goodbye!")
             break
 
         log.info(

--- a/scripts/step03_explore_examples/05_multi_modal_rag/main.py
+++ b/scripts/step03_explore_examples/05_multi_modal_rag/main.py
@@ -52,7 +52,7 @@ def main():
             continue
         elif option == "2":
             ask(llm, retriever)
-            break
+            continue
         elif option == "3":
             print("Goodbye!")
             sys.exit()


### PR DESCRIPTION
This PR refactors the code in the following ways,

1) Avoids exiting after running an example, only exit when it is specifically invoked

2) For the modules under 'Advanced RAG' samples, removed the __main__ block to disallow direct execution and make it consistent with other examples. 