### PR TITLE
Fix Dockerfile

### DIFF
--- a/config/Dockerfile
+++ b/config/Dockerfile
@@ -11,7 +11,7 @@ ENV TEMPFOLDER=/tmp/mytmp
 RUN apt-get update && apt-get install -y xdg-utils curl jq unzip git
 
 # Install Terraform CLI
-RUN TERRAFORM_VERSION=$(curl -s https://checkpoint-api.hashicorp.com/v1/check/terraform | jq -r .current_version) \
+RUN TERRAFORM_VERSION=$(curl -s https://checkpoint-api.hashicorp.com/v1/check/terraform | jq -r .current_version | sed 's/^v//') \
     && curl -O https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip \
     && unzip terraform_${TERRAFORM_VERSION}_linux_amd64.zip -d /usr/bin \
     && rm terraform_${TERRAFORM_VERSION}_linux_amd64.zip


### PR DESCRIPTION
Description - 

Issue - 

```
--------------------
ERROR: failed to solve: process "/bin/sh -c TERRAFORM_VERSION=$(curl -s https://checkpoint-api.hashicorp.com/v1/check/terraform | jq -r .current_version)     && curl -O https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip     && unzip terraform_${TERRAFORM_VERSION}_linux_amd64.zip -d /usr/bin     && rm terraform_${TERRAFORM_VERSION}_linux_amd64.zip" did not complete successfully: exit code: 9
```

In our Dockerfile - we fetch the latest version of terraform using the following command - 

```# Install Terraform CLI
RUN TERRAFORM_VERSION=$(curl -s https://checkpoint-api.hashicorp.com/v1/check/terraform | jq -r .current_version)
```

and subsequently use this version to fetch the terraform zip

```    
&& curl -O https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip \
    && unzip terraform_${TERRAFORM_VERSION}_linux_amd64.zip -d /usr/bin \
    && rm terraform_${TERRAFORM_VERSION}_linux_amd64.zip
```

however, the issue is that the TERRAFORM_VERSION is returned as ```v1.11.0``` whereas to download the zip we need to use ```1.11.0```.

Hence, the change is proposed which fixes this issue.

PS: In order to reproduce this issue, you might need to clear your docker cache.