### PR TITLE
chore: update btp provider version to ~> 1.16.1 

### DIFF
--- a/config/auto-updates/step01_setup_infra/modules/ai/ai.tf
+++ b/config/auto-updates/step01_setup_infra/modules/ai/ai.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     btp = {
       source  = "sap/btp"
-      version = "~> 1.10.0"
+      version = "~> 1.16.1"
     }
   }
 }

--- a/config/auto-updates/step01_setup_infra/provider.tf
+++ b/config/auto-updates/step01_setup_infra/provider.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     btp = {
       source  = "SAP/btp"
-      version = "~> 1.10.0"
+      version = "~> 1.16.1"
     }
   }
 }

--- a/scripts/step01_setup_infra/modules/ai/ai.tf
+++ b/scripts/step01_setup_infra/modules/ai/ai.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     btp = {
       source  = "sap/btp"
-      version = "~> 1.10.0"
+      version = "~> 1.16.1"
     }
   }
 }

--- a/scripts/step01_setup_infra/modules/hana-cloud/hana_cloud.tf
+++ b/scripts/step01_setup_infra/modules/hana-cloud/hana_cloud.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     btp = {
       source  = "sap/btp"
-      version = "~> 1.10.0"
+      version = "~> 1.16.1"
     }
   }
 }

--- a/scripts/step01_setup_infra/provider.tf
+++ b/scripts/step01_setup_infra/provider.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     btp = {
       source  = "SAP/btp"
-      version = "~> 1.10.0"
+      version = "~> 1.16.1"
     }
   }
 }


### PR DESCRIPTION
This PR updates the terraform provider for SAP BTP to the most current version.